### PR TITLE
Enable configuring in the same directory.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,11 +23,6 @@ AC_SUBST(LIBPAF_SO_VERSION)
 
 AC_CONFIG_SRCDIR([ebb/ebb.c])
 
-# We want to prevent building/configuration in the source directory
-if test "`cd $srcdir; /bin/pwd`" = "`/bin/pwd`"; then
-	AC_MSG_ERROR([you must configure in a separate build directory])
-fi
-
 # Check for supported platforms (currently only Linux on POWER)
 case "$host_cpu-$host_os" in
   powerpc64*-linux* | ppc64*-linux* | powerpc32*-linux | ppc32*-linux* )


### PR DESCRIPTION
This is a RFC patch to enable configuring in the same directory.
This is an effort to do paflib debianization, and, configuring in
a different directory is going to make the debianzation process harder.

So, do we really need to configure in a different directory?

Thanks
Breno

Signed-off-by: Breno Leitao <brenohl@br.ibm.com>