### PR TITLE
Change libpaf-common as libtool convenience library

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -1,2 +1,2 @@
-noinst_LIBRARIES = libpaf-common.a
-libpaf_common_a_SOURCES = paf-hwcap.c paf-interp.c paf-common.h paf-hwcap.h
+noinst_LTLIBRARIES = libpaf-common.la
+libpaf_common_la_SOURCES = paf-hwcap.c paf-interp.c paf-common.h paf-hwcap.h

--- a/common/Makefile.in
+++ b/common/Makefile.in
@@ -92,16 +92,14 @@ mkinstalldirs = $(install_sh) -d
 CONFIG_HEADER = $(top_builddir)/config.h
 CONFIG_CLEAN_FILES =
 CONFIG_CLEAN_VPATH_FILES =
-LIBRARIES = $(noinst_LIBRARIES)
-ARFLAGS = cru
-AM_V_AR = $(am__v_AR_@AM_V@)
-am__v_AR_ = $(am__v_AR_@AM_DEFAULT_V@)
-am__v_AR_0 = @echo "  AR      " $@;
-am__v_AR_1 = 
-libpaf_common_a_AR = $(AR) $(ARFLAGS)
-libpaf_common_a_LIBADD =
-am_libpaf_common_a_OBJECTS = paf-hwcap.$(OBJEXT) paf-interp.$(OBJEXT)
-libpaf_common_a_OBJECTS = $(am_libpaf_common_a_OBJECTS)
+LTLIBRARIES = $(noinst_LTLIBRARIES)
+libpaf_common_la_LIBADD =
+am_libpaf_common_la_OBJECTS = paf-hwcap.lo paf-interp.lo
+libpaf_common_la_OBJECTS = $(am_libpaf_common_la_OBJECTS)
+AM_V_lt = $(am__v_lt_@AM_V@)
+am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
+am__v_lt_0 = --silent
+am__v_lt_1 = 
 AM_V_P = $(am__v_P_@AM_V@)
 am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)
 am__v_P_0 = false
@@ -120,10 +118,6 @@ am__depfiles_maybe = depfiles
 am__mv = mv -f
 COMPILE = $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) \
 	$(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
-AM_V_lt = $(am__v_lt_@AM_V@)
-am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
-am__v_lt_0 = --silent
-am__v_lt_1 = 
 LTCOMPILE = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 	$(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) \
 	$(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) \
@@ -140,8 +134,8 @@ AM_V_CCLD = $(am__v_CCLD_@AM_V@)
 am__v_CCLD_ = $(am__v_CCLD_@AM_DEFAULT_V@)
 am__v_CCLD_0 = @echo "  CCLD    " $@;
 am__v_CCLD_1 = 
-SOURCES = $(libpaf_common_a_SOURCES)
-DIST_SOURCES = $(libpaf_common_a_SOURCES)
+SOURCES = $(libpaf_common_la_SOURCES)
+DIST_SOURCES = $(libpaf_common_la_SOURCES)
 am__can_run_installinfo = \
   case $$AM_UPDATE_INFO_DIR in \
     n|no|NO) false;; \
@@ -291,8 +285,8 @@ target_alias = @target_alias@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
-noinst_LIBRARIES = libpaf-common.a
-libpaf_common_a_SOURCES = paf-hwcap.c paf-interp.c paf-common.h paf-hwcap.h
+noinst_LTLIBRARIES = libpaf-common.la
+libpaf_common_la_SOURCES = paf-hwcap.c paf-interp.c paf-common.h paf-hwcap.h
 all: all-am
 
 .SUFFIXES:
@@ -328,13 +322,19 @@ $(ACLOCAL_M4): @MAINTAINER_MODE_TRUE@ $(am__aclocal_m4_deps)
 	cd $(top_builddir) && $(MAKE) $(AM_MAKEFLAGS) am--refresh
 $(am__aclocal_m4_deps):
 
-clean-noinstLIBRARIES:
-	-test -z "$(noinst_LIBRARIES)" || rm -f $(noinst_LIBRARIES)
+clean-noinstLTLIBRARIES:
+	-test -z "$(noinst_LTLIBRARIES)" || rm -f $(noinst_LTLIBRARIES)
+	@list='$(noinst_LTLIBRARIES)'; \
+	locs=`for p in $$list; do echo $$p; done | \
+	      sed 's|^[^/]*$$|.|; s|/[^/]*$$||; s|$$|/so_locations|' | \
+	      sort -u`; \
+	test -z "$$locs" || { \
+	  echo rm -f $${locs}; \
+	  rm -f $${locs}; \
+	}
 
-libpaf-common.a: $(libpaf_common_a_OBJECTS) $(libpaf_common_a_DEPENDENCIES) $(EXTRA_libpaf_common_a_DEPENDENCIES) 
-	$(AM_V_at)-rm -f libpaf-common.a
-	$(AM_V_AR)$(libpaf_common_a_AR) libpaf-common.a $(libpaf_common_a_OBJECTS) $(libpaf_common_a_LIBADD)
-	$(AM_V_at)$(RANLIB) libpaf-common.a
+libpaf-common.la: $(libpaf_common_la_OBJECTS) $(libpaf_common_la_DEPENDENCIES) $(EXTRA_libpaf_common_la_DEPENDENCIES) 
+	$(AM_V_CCLD)$(LINK)  $(libpaf_common_la_OBJECTS) $(libpaf_common_la_LIBADD) $(LIBS)
 
 mostlyclean-compile:
 	-rm -f *.$(OBJEXT)
@@ -342,8 +342,8 @@ mostlyclean-compile:
 distclean-compile:
 	-rm -f *.tab.c
 
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/paf-hwcap.Po@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/paf-interp.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/paf-hwcap.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/paf-interp.Plo@am__quote@
 
 .c.o:
 @am__fastdepCC_TRUE@	$(AM_V_CC)depbase=`echo $@ | sed 's|[^/]*$$|$(DEPDIR)/&|;s|\.o$$||'`;\
@@ -459,7 +459,7 @@ distdir: $(DISTFILES)
 	done
 check-am: all-am
 check: check-am
-all-am: Makefile $(LIBRARIES)
+all-am: Makefile $(LTLIBRARIES)
 installdirs:
 install: install-am
 install-exec: install-exec-am
@@ -493,7 +493,7 @@ maintainer-clean-generic:
 	@echo "it deletes files that may require special tools to rebuild."
 clean: clean-am
 
-clean-am: clean-generic clean-libtool clean-noinstLIBRARIES \
+clean-am: clean-generic clean-libtool clean-noinstLTLIBRARIES \
 	mostlyclean-am
 
 distclean: distclean-am
@@ -565,7 +565,7 @@ uninstall-am:
 .MAKE: install-am install-strip
 
 .PHONY: CTAGS GTAGS TAGS all all-am check check-am clean clean-generic \
-	clean-libtool clean-noinstLIBRARIES cscopelist-am ctags \
+	clean-libtool clean-noinstLTLIBRARIES cscopelist-am ctags \
 	ctags-am distclean distclean-compile distclean-generic \
 	distclean-libtool distclean-tags distdir dvi dvi-am html \
 	html-am info info-am install install-am install-data \

--- a/dsc/Makefile.am
+++ b/dsc/Makefile.am
@@ -13,9 +13,8 @@ libpaf_dsc_la_SOURCES = init.c \
                         $(include_HEADERS) \
                         $(INTERNAL_INCLUDES)
 libpaf_dsc_la_CFLAGS = -Wl,-entry=__paflib_dsc_main
-libpaf_dsc_la_LIBADD = $(LIBAUXV)
-libpaf_dsc_la_LDFLAGS = -version-info $(LIBPAF_SO_VERSION) \
-  -Wl,--whole-archive,../common/libpaf-common.a,--no-whole-archive
+libpaf_dsc_la_LIBADD = $(LIBAUXV) ../common/libpaf-common.la
+libpaf_dsc_la_LDFLAGS = -version-info $(LIBPAF_SO_VERSION)
 
 dist_man3_MANS = doc/libpaf-dsc.3
 

--- a/dsc/Makefile.in
+++ b/dsc/Makefile.in
@@ -126,7 +126,7 @@ am__uninstall_files_from_dir = { \
 am__installdirs = "$(DESTDIR)$(libdir)" "$(DESTDIR)$(man3dir)" \
 	"$(DESTDIR)$(includedir)"
 LTLIBRARIES = $(lib_LTLIBRARIES)
-libpaf_dsc_la_DEPENDENCIES =
+libpaf_dsc_la_DEPENDENCIES = ../common/libpaf-common.la
 am__objects_1 =
 am_libpaf_dsc_la_OBJECTS = libpaf_dsc_la-init.lo libpaf_dsc_la-dsc.lo \
 	libpaf_dsc_la-hwcap.lo libpaf_dsc_la-dsc-version.lo \
@@ -524,10 +524,8 @@ libpaf_dsc_la_SOURCES = init.c \
                         $(INTERNAL_INCLUDES)
 
 libpaf_dsc_la_CFLAGS = -Wl,-entry=__paflib_dsc_main
-libpaf_dsc_la_LIBADD = $(LIBAUXV)
-libpaf_dsc_la_LDFLAGS = -version-info $(LIBPAF_SO_VERSION) \
-  -Wl,--whole-archive,../common/libpaf-common.a,--no-whole-archive
-
+libpaf_dsc_la_LIBADD = $(LIBAUXV) ../common/libpaf-common.la
+libpaf_dsc_la_LDFLAGS = -version-info $(LIBPAF_SO_VERSION)
 dist_man3_MANS = doc/libpaf-dsc.3
 test_dsc_SOURCES = tests/test_dsc.c
 test_dsc_LDADD = libpaf-dsc.la

--- a/ebb/Makefile.am
+++ b/ebb/Makefile.am
@@ -27,9 +27,9 @@ libpaf_ebb_la_SOURCES = ebb.c \
                         ebb-callback.S
 
 libpaf_ebb_la_CFLAGS = -Wl,-entry=__paflib_ebb_main -fpic
+libpaf_ebb_la_LIBADD = ../common/libpaf-common.la
 libpaf_ebb_la_LDFLAGS = -version-info $(LIBPAF_SO_VERSION) \
-  -e __paflib_ebb_main \
-  -Wl,--whole-archive,../common/libpaf-common.a,--no-whole-archive
+  -e __paflib_ebb_main
 
 dist_man3_MANS = doc/libpaf-ebb.3
 

--- a/ebb/Makefile.in
+++ b/ebb/Makefile.in
@@ -138,7 +138,7 @@ am__uninstall_files_from_dir = { \
 am__installdirs = "$(DESTDIR)$(libdir)" "$(DESTDIR)$(man3dir)" \
 	"$(DESTDIR)$(includedir)"
 LTLIBRARIES = $(lib_LTLIBRARIES)
-libpaf_ebb_la_LIBADD =
+libpaf_ebb_la_DEPENDENCIES = ../common/libpaf-common.la
 am__objects_1 =
 am_libpaf_ebb_la_OBJECTS = libpaf_ebb_la-ebb.lo \
 	libpaf_ebb_la-ebb-init.lo libpaf_ebb_la-ebb-hwcap.lo \
@@ -607,9 +607,9 @@ libpaf_ebb_la_SOURCES = ebb.c \
                         ebb-callback.S
 
 libpaf_ebb_la_CFLAGS = -Wl,-entry=__paflib_ebb_main -fpic
+libpaf_ebb_la_LIBADD = ../common/libpaf-common.la
 libpaf_ebb_la_LDFLAGS = -version-info $(LIBPAF_SO_VERSION) \
-  -e __paflib_ebb_main \
-  -Wl,--whole-archive,../common/libpaf-common.a,--no-whole-archive
+  -e __paflib_ebb_main
 
 dist_man3_MANS = doc/libpaf-ebb.3
 test_ebb_SOURCES = tests/test_ebb.c


### PR DESCRIPTION
Test program in dsc fails with relocation error when compiling in
32 bit.  This is due to missing -fpic flag during compilation
of some of the files.

Signed-off-by: Rajalakshmi Srinivasaraghavan <raji@linux.vnet.ibm.com>

	* common/Makefile.am: Add fpic in CFLAGS.
	* common/Makefile.in: Regenerate.