### PR TITLE
Move tests from noinst_PROGRAMS to check_PROGRAMS

### DIFF
--- a/ebb/Makefile.am
+++ b/ebb/Makefile.am
@@ -83,22 +83,22 @@ TESTS                  += test_ebb_child
 test_ebb_child_SOURCES  = tests/test_ebb_child.c \
                           tests/test_ebb_common.c
 test_ebb_child_LDADD    = libpaf-ebb.la
-noinst_PROGRAMS        += test_ebb_child
+check_PROGRAMS        += test_ebb_child
 
 TESTS                           += test_ebb_clear_on_close
 test_ebb_clear_on_close_SOURCES  = tests/test_ebb_clear_on_close.c \
                                    tests/test_ebb_common.c
 test_ebb_clear_on_close_LDADD    = libpaf-ebb.la
-noinst_PROGRAMS                 += test_ebb_clear_on_close
+check_PROGRAMS                 += test_ebb_clear_on_close
 
 TESTS                      += test_ebb_nohandler
 test_ebb_nohandler_SOURCES  = tests/test_ebb_nohandler.c \
                               tests/test_ebb_common.c
 test_ebb_nohandler_LDADD    = libpaf-ebb.la
-noinst_PROGRAMS            += test_ebb_nohandler
+check_PROGRAMS            += test_ebb_nohandler
 
 TESTS                += test_ebb_cpu
 test_ebb_cpu_SOURCES  = tests/test_ebb_cpu.c \
                         tests/test_ebb_common.c
 test_ebb_cpu_LDADD    = libpaf-ebb.la
-noinst_PROGRAMS      += test_ebb_cpu
+check_PROGRAMS      += test_ebb_cpu

--- a/ebb/Makefile.in
+++ b/ebb/Makefile.in
@@ -80,12 +80,12 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 build_triplet = @build@
 host_triplet = @host@
-noinst_PROGRAMS = test_ebb_child$(EXEEXT) \
-	test_ebb_clear_on_close$(EXEEXT) test_ebb_nohandler$(EXEEXT) \
-	test_ebb_cpu$(EXEEXT)
+noinst_PROGRAMS =
 check_PROGRAMS = test_ebb$(EXEEXT) test_ebb_pmu$(EXEEXT) \
 	test_ebb_pmu_reset$(EXEEXT) test_ebb_backtrace$(EXEEXT) \
-	test_ebb_pmu_multi$(EXEEXT) test_ebb_pmu_clobber$(EXEEXT)
+	test_ebb_pmu_multi$(EXEEXT) test_ebb_pmu_clobber$(EXEEXT) \
+	test_ebb_child$(EXEEXT) test_ebb_clear_on_close$(EXEEXT) \
+	test_ebb_nohandler$(EXEEXT) test_ebb_cpu$(EXEEXT)
 TESTS = test_ebb$(EXEEXT) test_ebb_save_area_env.sh$(EXEEXT) \
 	test_ebb_pmu$(EXEEXT) test_ebb_pmu_reset$(EXEEXT) \
 	test_ebb_backtrace$(EXEEXT) test_ebb_pmu_multi$(EXEEXT) \

--- a/tb/Makefile.am
+++ b/tb/Makefile.am
@@ -11,4 +11,4 @@ dist_man3_MANS = doc/libpaf-tb.3
 TESTS = test_tb
 test_tb_SOURCES = tests/test_tb.c
 
-noinst_PROGRAMS = $(TESTS)
+check_PROGRAMS = $(TESTS)

--- a/tb/Makefile.in
+++ b/tb/Makefile.in
@@ -14,7 +14,6 @@
 
 @SET_MAKE@
 
-
 VPATH = @srcdir@
 am__is_gnu_make = test -n '$(MAKEFILE_LIST)' && test -n '$(MAKELEVEL)'
 am__make_running_with_option = \
@@ -80,7 +79,7 @@ POST_UNINSTALL = :
 build_triplet = @build@
 host_triplet = @host@
 TESTS = test_tb$(EXEEXT)
-noinst_PROGRAMS = $(am__EXEEXT_1)
+check_PROGRAMS = $(am__EXEEXT_1)
 subdir = tb
 DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
 	$(top_srcdir)/depcomp $(dist_man3_MANS) \
@@ -97,7 +96,6 @@ CONFIG_HEADER = $(top_builddir)/config.h
 CONFIG_CLEAN_FILES =
 CONFIG_CLEAN_VPATH_FILES =
 am__EXEEXT_1 = test_tb$(EXEEXT)
-PROGRAMS = $(noinst_PROGRAMS)
 am__dirstamp = $(am__leading_dot)dirstamp
 am_test_tb_OBJECTS = tests/test_tb.$(OBJEXT)
 test_tb_OBJECTS = $(am_test_tb_OBJECTS)
@@ -544,8 +542,8 @@ $(ACLOCAL_M4): @MAINTAINER_MODE_TRUE@ $(am__aclocal_m4_deps)
 	cd $(top_builddir) && $(MAKE) $(AM_MAKEFLAGS) am--refresh
 $(am__aclocal_m4_deps):
 
-clean-noinstPROGRAMS:
-	@list='$(noinst_PROGRAMS)'; test -n "$$list" || exit 0; \
+clean-checkPROGRAMS:
+	@list='$(check_PROGRAMS)'; test -n "$$list" || exit 0; \
 	echo " rm -f" $$list; \
 	rm -f $$list || exit $$?; \
 	test -n "$(EXEEXT)" || exit 0; \
@@ -851,7 +849,7 @@ check-TESTS:
 	log_list=`echo $$log_list`; trs_list=`echo $$trs_list`; \
 	$(MAKE) $(AM_MAKEFLAGS) $(TEST_SUITE_LOG) TEST_LOGS="$$log_list"; \
 	exit $$?;
-recheck: all 
+recheck: all $(check_PROGRAMS)
 	@test -z "$(TEST_SUITE_LOG)" || rm -f $(TEST_SUITE_LOG)
 	@set +e; $(am__set_TESTS_bases); \
 	bases=`for i in $$bases; do echo $$i; done \
@@ -915,9 +913,10 @@ distdir: $(DISTFILES)
 	  fi; \
 	done
 check-am: all-am
+	$(MAKE) $(AM_MAKEFLAGS) $(check_PROGRAMS)
 	$(MAKE) $(AM_MAKEFLAGS) check-TESTS
 check: check-am
-all-am: Makefile $(PROGRAMS) $(MANS) $(HEADERS)
+all-am: Makefile $(MANS) $(HEADERS)
 installdirs:
 	for dir in "$(DESTDIR)$(man3dir)" "$(DESTDIR)$(includedir)"; do \
 	  test -z "$$dir" || $(MKDIR_P) "$$dir"; \
@@ -959,7 +958,7 @@ maintainer-clean-generic:
 	@echo "it deletes files that may require special tools to rebuild."
 clean: clean-am
 
-clean-am: clean-generic clean-libtool clean-noinstPROGRAMS \
+clean-am: clean-checkPROGRAMS clean-generic clean-libtool \
 	mostlyclean-am
 
 distclean: distclean-am
@@ -1033,7 +1032,7 @@ uninstall-man: uninstall-man3
 .MAKE: check-am install-am install-strip
 
 .PHONY: CTAGS GTAGS TAGS all all-am check check-TESTS check-am clean \
-	clean-generic clean-libtool clean-noinstPROGRAMS cscopelist-am \
+	clean-checkPROGRAMS clean-generic clean-libtool cscopelist-am \
 	ctags ctags-am distclean distclean-compile distclean-generic \
 	distclean-libtool distclean-tags distdir dvi dvi-am html \
 	html-am info info-am install install-am install-data \


### PR DESCRIPTION
This patch makes the test programs to build only during make check
instead of make.

Signed-off-by:  Rajalakshmi Srinivasaraghavan  <raji@linux.vnet.ibm.com>

	* ebb/Makefile.am: Change noinst_PROGRAMS to check_PROGRAMS.
	* ebb/Makefile.in: Regenerate.
	* tb/Makefile.am: Change noinst_PROGRAMS to check_PROGRAMS.
	* tb/Makefile.in: Regenerate.