### PR TITLE
Fix error in libpaf-dsc and libpaf-ebb man pages example

### DIFF
--- a/dsc/doc/libpaf-dsc.3
+++ b/dsc/doc/libpaf-dsc.3
@@ -52,47 +52,40 @@ available on Power Architecture. This register follows the layout specified in
 the corresponding Power ISA, with the following defined flags.
 
 These are features supported by Power ISA 2.05:
-.TP
+.LP
 .IP \[bu] 2
 .BR DSCR_SSE
 Store Stream Enable.
 
-.PP
+.LP
 These features were added on Power ISA 2.06:
-.TP
 .IP \[bu] 2
 .BR DSCR_SNSE
 Stride-N Stream Enable.
-.PP
+
+.LP
 These features were added on Power ISA 2.06+:
-.TP
 .IP \[bu] 2
 .BR DSCR_LSD
 Load Stream Disable.
 
-.PP
+.LP
 These are supported only on Power ISA 2.07:
-.TP
 .IP \[bu] 2
 .BR DSCR_HWUE
 Hardware Unit count Enable.
-.TP
 .IP \[bu] 2
 .BR DSCR_SWUE
 Software Unit count Enable.
-.TP
 .IP \[bu]
 .BR DSCR_LTE
 Load Transient Enable.
-.TP
 .IP \[bu]
 .BR DSCR_STE
 Software Transient Enable.
-.TP
 .IP \[bu]
 .BR DSCR_HTE
 Hardware Transient Enable.
-.TP
 .IP \[bu]
 .BR DSCR_SWTE
 Software Transient Enable. 
@@ -201,6 +194,7 @@ if the system does not support DSCR facility.
 .nf
 #include <inttypes.h>
 #include <paf/dsc.h>
+#include <assert.h>
 
 int main(void)
 {

--- a/ebb/doc/libpaf-ebb.3
+++ b/ebb/doc/libpaf-ebb.3
@@ -279,7 +279,7 @@ void do_work (void)
     }
 }
 
-int _do_ebb(void)
+int do_ebb(void)
 {
   ebbhandler_t handler;
   ebb_handler_triggered = 0;
@@ -302,7 +302,7 @@ int _do_ebb(void)
 
   paf_ebb_disable_branches ();
 
-  printf ("Done; %d EBB interrupts handled\n", ebb_handler_triggered);
+  printf ("Done; %d EBB interrupts handled\\n", ebb_handler_triggered);
 
   close (ebb_fd);
 


### PR DESCRIPTION
Hi,

This patch addresses minor errors in libpaf-dsc and libpaf-ebb man pages example. Also fixes wrong content formatting of  libpaf-dsc man page on ppc64 machine with reduced terminal size. Works fine on x86_64 machine as well.

For reference following are screenshots of  libpaf-dsc man page:
* Without applying patch and terminal in full screen mode: https://sinnykumari.fedorapeople.org/screenshots/paflib/paflib_man_page_ppc64_full_screen_konsole.jpeg
* Without applying patch and terminal is in reduced size: https://sinnykumari.fedorapeople.org/screenshots/paflib/paflib_man_page_ppc64.jpeg
* After applying patch and terminal is in reduced size: https://sinnykumari.fedorapeople.org/screenshots/paflib/paflib_man_page_ppc64_after_patch.jpeg

Thanks,
Sinny